### PR TITLE
Move indicator to accommodate slowmode

### DIFF
--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@
   pointer-events: none;
   display: block;
   position: absolute;
-  right: 16px;
+  right: 360px;
   bottom: .2em;
   z-index: 1;
 }


### PR DESCRIPTION
I'm really not sure if this is the best way to do it, but when slowmode is enabled (and you're immune) there needs to be 360px or the WPM indicator is hidden under the slowmode indicator. When not immune, around 70px is needed.